### PR TITLE
Add EXPOSE Dockerfile directive

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,4 +4,6 @@ RUN mkdir /app
 
 ADD /build/libs/yaade-server-1.0-SNAPSHOT.jar /app/yaade.jar
 
+EXPOSE 9339
+
 CMD [ "java", "-jar", "/app/yaade.jar"]


### PR DESCRIPTION
Helps tools (like Traefik) to detect 'registered' ports for forwarding and discovery