### PR TITLE
feat: add manifest v3 for firefox

### DIFF
--- a/extension/manifest_ffv3.json
+++ b/extension/manifest_ffv3.json
@@ -1,0 +1,27 @@
+{
+  "name": "Yaade Extension",
+  "description": "An extension to enhance Yaade functionality",
+  "version": "1.7",
+  "manifest_version": 3,
+  "host_permissions": ["<all_urls>"],
+  "permissions": ["storage"],
+  "action": {
+    "default_popup": "/popup/popup.html"
+  },
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "run_at": "document_idle",
+      "js": ["contentScript.js"]
+    }
+  ],
+  "icons": {
+    "36": "icons/android-icon-36x36.png",
+    "48": "icons/android-icon-48x48.png",
+    "72": "icons/android-icon-72x72.png",
+    "192": "icons/android-icon-192x192.png"
+  }
+}


### PR DESCRIPTION
With Mozillas adaption of manifest v3, we can add a firefox extension with a minimal change in the manifest.
The change is needed as service_worker property [isn't supported yet](https://github.com/mozilla/web-ext/issues/2532).
Compability for firefox is tested with https://www.extensiontest.com/.

Resolves #15