### PR TITLE
fix: hardcoded DB connection

### DIFF
--- a/server/src/main/kotlin/com/espero/yaade/Main.kt
+++ b/server/src/main/kotlin/com/espero/yaade/Main.kt
@@ -7,10 +7,10 @@ import com.espero.yaade.server.Server
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 
-const val PORT = 9339
-const val JDBC_URL = "jdbc:h2:file:./app/data/yaade-db"
-const val JDBC_USR = "sa"
-const val JDBC_PWD = ""
+val PORT = System.getenv("PORT").toInt() ?: 9339
+val JDBC_URL = System.getenv("YAADE_JDBC_URL") ?: "jdbc:h2:file:./app/data/yaade-db"
+val JDBC_USR = System.getenv("YAADE_JDBC_USERNAME") ?: "sa"
+val JDBC_PWD = System.getenv("YAADE_JDBC_PASSWORD") ?: ""
 val ADMIN_USERNAME: String = System.getenv("YAADE_ADMIN_USERNAME") ?: ""
 val BASE_PATH: String = System.getenv("YAADE_BASE_PATH") ?: ""
 

--- a/server/src/main/kotlin/com/espero/yaade/Main.kt
+++ b/server/src/main/kotlin/com/espero/yaade/Main.kt
@@ -7,7 +7,7 @@ import com.espero.yaade.server.Server
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 
-val PORT = System.getenv("PORT").toInt() ?: 9339
+val PORT = System.getenv("YAADE_PORT").toInt() ?: 9339
 val JDBC_URL = System.getenv("YAADE_JDBC_URL") ?: "jdbc:h2:file:./app/data/yaade-db"
 val JDBC_USR = System.getenv("YAADE_JDBC_USERNAME") ?: "sa"
 val JDBC_PWD = System.getenv("YAADE_JDBC_PASSWORD") ?: ""


### PR DESCRIPTION
DB connection is very hardcoded right now, meaning I can't run it against a database and thus can only run a single instance.

I'm assuming the rest of the implementation is fine (stupid) but as long as the jdbc URL is exposed then the ORM should already have everything I need.

Also made PORT configurable from an env-var as `PORT` as an env var is require for FaaS platforms (Cloud Run, OpenFaaS etc;)