### PR TITLE
fix secret interpolation in headers

### DIFF
--- a/server/src/main/kotlin/com/espero/yaade/services/SecretInterpolator.kt
+++ b/server/src/main/kotlin/com/espero/yaade/services/SecretInterpolator.kt
@@ -6,32 +6,42 @@ import io.vertx.core.json.JsonObject;
 import org.apache.commons.text.StringSubstitutor
 
 class SecretInterpolator(private val daoManager: DaoManager) {
+
     fun interpolate(request: JsonObject, collectionId: Long?, envName: String): JsonObject {
         if (collectionId == null)
             return request
-        val secrets: JsonObject = daoManager.collectionDao.getSecrets(collectionId, envName) ?: return request
+        val secrets: JsonObject =
+            daoManager.collectionDao.getSecrets(collectionId, envName) ?: return request
         if (secrets.isEmpty)
             return request
         val substitutor = StringSubstitutor(secrets.map)
-        return JsonObject(interpolate2(request.map as Map<String, Any>, substitutor))
+        return interpolate2(request, substitutor)
     }
 
-     private fun interpolate2(request: Map<String, Any>, substitutor: StringSubstitutor ) : Map<String, Any> {
-        return request.mapValues { interpolate1(it.value, substitutor)}
+    private fun interpolate2(
+        request: JsonObject,
+        substitutor: StringSubstitutor
+    ): JsonObject {
+        val result = JsonObject()
+        request.forEach {
+            result.put(it.key, interpolate1(it.value, substitutor))
+        }
+
+        return result
     }
 
     private fun interpolate1(value: Any, substitutor: StringSubstitutor): Any {
-            return when (value) {
-                is String -> interpolate0(value, substitutor)
-                is JsonObject -> interpolate2(value.map, substitutor)
-                is JsonArray -> value.map { interpolate1(it, substitutor) }
-                else -> value
-            }
+        return when (value) {
+            is String -> interpolate0(value, substitutor)
+            is JsonObject -> interpolate2(value, substitutor)
+            is JsonArray -> value.map { interpolate1(it, substitutor) }
+            else -> value
+        }
     }
 
     private fun interpolate0(value: String, substitutor: StringSubstitutor): String {
-            if (!value.contains("\$S{"))
-                return value
+        if (!value.contains("\$S{"))
+            return value
         val v = value.replace("\$S{", "\${")
         return substitutor.replace(v)
     }


### PR DESCRIPTION
bug where the map of a JsonObject does not return JsonObjects and JsonArrays, but lists and Maps.

Fix it by passing the JsonObject directly without converting it to a map.