### PR TITLE
added new timezone options and date variable assignment

### DIFF
--- a/client/src/utils/parseResponseEvent.tsx
+++ b/client/src/utils/parseResponseEvent.tsx
@@ -24,7 +24,19 @@ function parseResponse(res: any): Response {
   }
   const size = res.size ?? getSize(headers);
 
-  const date = new Date().toUTCString();
+
+  const options: Intl.DateTimeFormatOptions = { 
+    weekday: 'long', 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric', 
+    hour: '2-digit', 
+    minute: '2-digit', 
+    second: '2-digit', 
+    timeZoneName: 'short'
+  };
+  const date = new Date().toLocaleString('en-GB', options);
+
 
   return {
     headers,


### PR DESCRIPTION
I am quite bad at javascript but I noodled and tried to implement the least impactful change that would respect the user's timezone in the timestamp.  I'm american but I set it as en-GB as right now the variable is in UTC. feedback is welcome, or tell me to just make a feature request if its better for someone who knows what they're doing to handle it.

this is also my first ever contribution on github so I apologize if I did something wrong.