### PR TITLE
fix: correct switch content-type

### DIFF
--- a/client/src/components/requestPanel/RequestSender.tsx
+++ b/client/src/components/requestPanel/RequestSender.tsx
@@ -202,7 +202,8 @@ function RequestSender({
 
     let body;
     switch (request.data.contentType) {
-      case 'application/x-www-form-urlencoded' || 'multipart/form-data':
+      case 'multipart/form-data':
+      case 'application/x-www-form-urlencoded':
         if (request.data.formDataBody) {
           body = encodeFormDataBody(request.data.formDataBody);
         }


### PR DESCRIPTION
In js (a || b) evaluates to a. 
In this case that means, that the switch case for the content-type never goes into `case: urlencoded || multipart` if the value is `multipart`. 

In a case where the code for multiple case values is identical, it's fine to you the fallthrough property of a switch case statement. 

```
case a:
case b:
code
```