### PR TITLE
fix: settings modal overflow

### DIFF
--- a/client/src/components/settings/Settings.module.css
+++ b/client/src/components/settings/Settings.module.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  height: 600px;
+  height: 680px;
 }
 
 .tabListWrapper {

--- a/client/src/components/settings/Settings.tsx
+++ b/client/src/components/settings/Settings.tsx
@@ -68,7 +68,12 @@ function Settings() {
           </TabList>
         </div>
 
-        <TabPanels tabIndex={-1}>
+        <TabPanels
+          tabIndex={-1}
+          overflowY="auto"
+          sx={{ scrollbarGutter: 'stable' }}
+          h="100%"
+        >
           <TabPanel tabIndex={-1}>
             <GeneralSettings />
           </TabPanel>

--- a/client/src/components/settings/userSettings/providerTabs/LocalProviderTab.tsx
+++ b/client/src/components/settings/userSettings/providerTabs/LocalProviderTab.tsx
@@ -185,7 +185,7 @@ const LocalProviderTab: FunctionComponent<LocalProviderTabProps> = ({
           />
         </div>
       </HStack>
-      <TableContainer height="330px" overflowY="scroll">
+      <TableContainer overflowY="scroll">
         <Table size="sm" whiteSpace="normal">
           <Thead>
             <Tr>
@@ -268,7 +268,12 @@ const LocalProviderTab: FunctionComponent<LocalProviderTabProps> = ({
                       </Tag>
                     ))}
                   </Td>
-                  <Td p="0" isNumeric verticalAlign="top">
+                  <Td
+                    p="0"
+                    isNumeric
+                    verticalAlign="top"
+                    style={{ display: 'flex', alignItems: 'center' }}
+                  >
                     <IconButton
                       aria-label="edit-row"
                       isRound


### PR DESCRIPTION
This PR makes the settings modal scrollable instead of static height.
It also slightly increases its size, so there is no scrollbar for an empty instance.

Closes #160 